### PR TITLE
struktur lag-oversikt og lag-sider

### DIFF
--- a/_lag/barn/azur.md
+++ b/_lag/barn/azur.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Azur'
     kontaktperson: 'Jarle Monsen'
     fiksid: '36315'
+slug: azur
 ---

--- a/_lag/barn/brontosaurus.md
+++ b/_lag/barn/brontosaurus.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Brontosaurus'
     kontaktperson: 'Carsten Wiegard'
     fiksid: null
+slug: brontosaurus
 ---

--- a/_lag/barn/cobra.md
+++ b/_lag/barn/cobra.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Cobra B'
     kontaktperson: 'Øyvind Håkon Heimli'
     fiksid: null
+slug: cobra
 ---

--- a/_lag/barn/fiolett.md
+++ b/_lag/barn/fiolett.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Fiolett'
     kontaktperson: 'Ronny Nynes'
     fiksid: '20816'
+slug: fiolett
 ---

--- a/_lag/barn/gaupe.md
+++ b/_lag/barn/gaupe.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Gaupe B'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: gaupe
 ---

--- a/_lag/barn/gepard.md
+++ b/_lag/barn/gepard.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Gepard'
     kontaktperson: 'Ove Sture'
     fiksid: null
+slug: gepard
 ---

--- a/_lag/barn/gold.md
+++ b/_lag/barn/gold.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Gold'
     kontaktperson: 'Ole-Ivar Guleng'
     fiksid: '19566'
+slug: gold
 ---

--- a/_lag/barn/hai.md
+++ b/_lag/barn/hai.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Hai B'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: hai
 ---

--- a/_lag/barn/jaguar.md
+++ b/_lag/barn/jaguar.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Jaguar'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: jaguar
 ---

--- a/_lag/barn/leopard.md
+++ b/_lag/barn/leopard.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Leopard'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: leopard
 ---

--- a/_lag/barn/love.md
+++ b/_lag/barn/love.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Løve'
     kontaktperson: 'Vidar Haugland'
     fiksid: null
+slug: love
 ---

--- a/_lag/barn/magenta.md
+++ b/_lag/barn/magenta.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Magenta'
     kontaktperson: 'Simen Martinussen Mittet'
     fiksid: '19564'
+slug: magenta
 ---

--- a/_lag/barn/mar.md
+++ b/_lag/barn/mar.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Mår B'
     kontaktperson: 'Pål Bøthun'
     fiksid: null
+slug: mar
 ---

--- a/_lag/barn/marihone.md
+++ b/_lag/barn/marihone.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Marihøne Rød'
     kontaktperson: 'Lisbeth Larsen'
     fiksid: null
+slug: marihone
 ---

--- a/_lag/barn/mink.md
+++ b/_lag/barn/mink.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Mink'
     kontaktperson: 'Hallgeir Nesheim'
     fiksid: null
+slug: mink
 ---

--- a/_lag/barn/orn.md
+++ b/_lag/barn/orn.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Ørn'
     kontaktperson: 'Willy Sture'
     fiksid: null
+slug: orn
 ---

--- a/_lag/barn/panter.md
+++ b/_lag/barn/panter.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Panter'
     kontaktperson: 'Vidar Skjønborg'
     fiksid: null
+slug: panter
 ---

--- a/_lag/barn/pegasus.md
+++ b/_lag/barn/pegasus.md
@@ -17,4 +17,5 @@ teams:
     name: 'Askøy Pegasus C'
     kontaktperson: 'Frode Fjell'
     fiksid: null
+slug: pegasus
 ---

--- a/_lag/barn/pink.md
+++ b/_lag/barn/pink.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Pink'
     kontaktperson: 'Marianne Helgheim'
     fiksid: '35752'
+slug: pink
 ---

--- a/_lag/barn/puma.md
+++ b/_lag/barn/puma.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Puma A'
     kontaktperson: 'Kristian Johannessen'
     fiksid: null
+slug: puma
 ---

--- a/_lag/barn/purple.md
+++ b/_lag/barn/purple.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Purple'
     kontaktperson: 'Gard Stigen'
     fiksid: '37571'
+slug: purple
 ---

--- a/_lag/barn/reptil.md
+++ b/_lag/barn/reptil.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Reptil'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: reptil
 ---

--- a/_lag/barn/royskatt.md
+++ b/_lag/barn/royskatt.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Røyskatt B'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: royskatt
 ---

--- a/_lag/barn/rubin.md
+++ b/_lag/barn/rubin.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Rubin'
     kontaktperson: 'Monica Hanselmann'
     fiksid: '19565'
+slug: rubin
 ---

--- a/_lag/barn/safir.md
+++ b/_lag/barn/safir.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Safir'
     kontaktperson: 'Vidar Johannessen'
     fiksid: '21184'
+slug: safir
 ---

--- a/_lag/barn/signalrod.md
+++ b/_lag/barn/signalrod.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Signalrød'
     kontaktperson: 'Trond Jakobsen'
     fiksid: '35751'
+slug: signalrod
 ---

--- a/_lag/barn/skogmus.md
+++ b/_lag/barn/skogmus.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Skogmus B'
     kontaktperson: 'Olav Skogen'
     fiksid: null
+slug: skogmus
 ---

--- a/_lag/barn/t-rex.md
+++ b/_lag/barn/t-rex.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy T-Rex'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: t-rex
 ---

--- a/_lag/barn/tiger.md
+++ b/_lag/barn/tiger.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Tiger 07'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: tiger
 ---

--- a/_lag/barn/turkis.md
+++ b/_lag/barn/turkis.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Turkis A'
     kontaktperson: 'Eirik Vonheim'
     fiksid: '19563'
+slug: turkis
 ---

--- a/_lag/barn/ulv.md
+++ b/_lag/barn/ulv.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy Ulv B'
     kontaktperson: 'Trond Holmedal'
     fiksid: null
+slug: ulv
 ---

--- a/_lag/barn/veps.md
+++ b/_lag/barn/veps.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Veps'
     kontaktperson: 'Trond Marøy'
     fiksid: null
+slug: veps
 ---

--- a/_lag/barn/villkatt.md
+++ b/_lag/barn/villkatt.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Villkatt'
     kontaktperson: 'Ove Sture'
     fiksid: null
+slug: villkatt
 ---

--- a/_lag/senior/a.md
+++ b/_lag/senior/a.md
@@ -9,4 +9,5 @@ teams:
     name: Askøy
     kontaktperson: 'Ketil Kleppe'
     fiksid: '666'
+slug: a
 ---

--- a/_lag/senior/veteran.md
+++ b/_lag/senior/veteran.md
@@ -9,4 +9,5 @@ teams:
     name: Askøy
     kontaktperson: 'Frode Jensen'
     fiksid: '165410'
+slug: veteran
 ---

--- a/_lag/stjerne/stjerne.md
+++ b/_lag/stjerne/stjerne.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Stjerne'
     kontaktperson: 'Monica Solberg'
     fiksid: null
+slug: stjerne
 ---

--- a/_lag/ungdom/g13.md
+++ b/_lag/ungdom/g13.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy 2'
     kontaktperson: 'Bjørn Juvik'
     fiksid: '32401'
+slug: g13
 ---

--- a/_lag/ungdom/g14.md
+++ b/_lag/ungdom/g14.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy 2'
     kontaktperson: 'Jarl Aspunvik'
     fiksid: '19846'
+slug: g14
 ---

--- a/_lag/ungdom/g16.md
+++ b/_lag/ungdom/g16.md
@@ -17,4 +17,5 @@ teams:
     name: 'Askøy G16 3'
     kontaktperson: 'Lars Dahl'
     fiksid: '146500'
+slug: g16
 ---

--- a/_lag/ungdom/g19.md
+++ b/_lag/ungdom/g19.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy G19 2'
     kontaktperson: 'Ove Sture'
     fiksid: '146503'
+slug: g19
 ---

--- a/_lag/ungdom/j13.md
+++ b/_lag/ungdom/j13.md
@@ -13,4 +13,5 @@ teams:
     name: 'Askøy 2'
     kontaktperson: 'Arild Hjelle'
     fiksid: '155044'
+slug: j13
 ---

--- a/_lag/ungdom/j14.md
+++ b/_lag/ungdom/j14.md
@@ -9,4 +9,5 @@ teams:
     name: 'Askøy Fk/Askøy Sk'
     kontaktperson: 'Tommy Jakobsen'
     fiksid: '32371'
+slug: j14
 ---

--- a/_layouts/collections-list-lag.html
+++ b/_layouts/collections-list-lag.html
@@ -1,0 +1,89 @@
+---
+layout: default
+---
+
+<main>
+
+    
+    <h1 class="post-title">{{ page.title }}</h1>
+
+
+
+    {% assign segments = page.url | split: '/' %}
+    {% assign category = segments[2] %}
+
+
+    {% assign barn = (site.lag | where: 'category', 'barn' | sort: 'age') %}
+    {% assign ungdom = (site.lag | where: 'category', 'ungdom' | sort: 'age') %}
+    {% assign senior = (site.lag | where: 'category', 'senior') %}
+    {% assign stjerne = (site.lag | where: 'category', 'stjerne') %}
+
+
+    {% if category != null %}
+        {% assign current = (site.lag | where: 'category', category | sort: 'age' ) %}
+    {% endif %}
+
+
+    <p>Dette blir en oversikt over {{ collection }} med linker videre. Design kommer når struktur er på plass.</p>
+
+
+{% if category == null %}
+
+    <h2><a href="/lag/barn/">Barn</a></h2>
+
+    <ul>
+        {% for lag in barn %}
+        <li><a href="/lag/barn/{{ lag.slug }}">{{ lag.title }} ({{ lag.sex }} {{ lag.age }} år)</a></li>
+        {% endfor %}
+    </ul>
+
+
+    <h2><a href="/lag/ungdom/">Ungdom</a></h2>
+
+    <ul>
+        {% for lag in ungdom %}
+        <li><a href="/lag/ungdom/{{ lag.slug }}">{{ lag.title }} ({{ lag.sex }} {{ lag.age }} år)</a></li>
+        {% endfor %}
+    </ul>
+
+
+    <h2><a href="/lag/senior/">Senior</a></h2>
+
+    <ul>
+        {% for lag in senior %}
+        <li><a href="/lag/senior/{{ lag.slug }}">{{ lag.title }}</a></li>
+        {% endfor %}
+    </ul>
+
+    <h2><a href="/lag/stjerne/">Stjerne</a></h2>
+
+    <ul>
+        {% for lag in stjerne %}
+        <li><a href="/lag/stjerne">{{ lag.title }}</a></li>
+        {% endfor %}
+    </ul>
+
+    {% else %}
+
+        <ul>
+            {% for lag in current %}
+            <li><a href="/lag/{{ category }}/{{ lag.slug }}">{{ lag.title }}
+
+                {% if category == 'barn' or category == 'ungdom' %}
+
+                ({{ lag.sex }} {{ lag.age }} år)
+
+                {% endif %}
+
+                </a></li>
+            {% endfor %}
+        </ul>
+
+
+
+    {% endif %}
+
+
+
+
+</main>

--- a/_layouts/collections-list.html
+++ b/_layouts/collections-list.html
@@ -11,12 +11,18 @@ layout: default
     {% assign segments = page.url | split: '/' %}
     {% assign collection = segments[1] %}
 
+
     <p>Dette blir en oversikt over {{ collection }} med linker videre. Design kommer når struktur er på plass.</p>
+
 
     <ul>
 
-    {% for collection in site[collection] %}
-      <li>{{ collection.title }}</li>
+
+
+    {% for item in site[collection] %}
+
+      <li>{{ item.title }}</li>
+
     {% endfor %}
 
     </ul>

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -2,4 +2,7 @@
 layout: default
 ---
 
-<h1>{{ page.title }}</h1>
+<main>
+    <h1>{{ page.title }}</h1>
+    <p>Info, tabeller, treningstider, kontaktpersoner etc.</p>    
+</main>

--- a/index.html
+++ b/index.html
@@ -13,25 +13,25 @@ layout: default
       <div class="g-medium--half g-wide--1 front-page-box">
           <h2>Barn</h2>
           <p>Vi har over 50 barnelag fra 1.–7. klasse</p>
-          <button class="button--primary">Les mer</button>
+          <a href="/lag/barn/" class="button--primary">Les mer</a>
       </div>
 
       <div class="g-medium--half g-medium--last g-wide--1 front-page-box">
           <h2>Ungdom</h2>
           <p>Vi er opptatt av å gi alle ungdommene et godt tilbud.</p>
-          <button class="button--primary">Les mer</button>
+          <a href="/lag/ungdom/" class="button--primary">Les mer</a>
       </div>
 
       <div class="g-medium--half g-wide--1 front-page-box">
           <h2>Junior/Senior</h2>
           <p>Askøy Fotballklubb har svært gode ungdommer på vei opp i seniorfotballen.</p>
-          <button class="button--primary">Les mer</button>
+          <a href="/lag/senior/" class="button--primary">Les mer</a>
       </div>
 
       <div class="g-medium--half g-medium--last g-wide--1 g-wide--last front-page-box">
         <h2>Stjernelag</h2>
         <p>Askøy Fotballklubbs lag for funksjonshemmede.</p>
-        <button class="button--primary">Les mer</button>
+        <a href="/lag/stjerne/" class="button--primary">Les mer</a>
 
       </div>
     </main>

--- a/lag/barn.md
+++ b/lag/barn.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: collections-list-lag
 title: Barn
 permalink: /lag/barn/
 ---

--- a/lag/index.md
+++ b/lag/index.md
@@ -1,5 +1,5 @@
 ---
-layout: collections-list
+layout: collections-list-lag
 title: Lag
 permalink: /lag/
 ---

--- a/lag/senior.md
+++ b/lag/senior.md
@@ -1,0 +1,7 @@
+---
+layout: collections-list-lag
+title: Senior
+permalink: /lag/senior/
+---
+
+Oversikt over senior-lagene

--- a/lag/stjerne.md
+++ b/lag/stjerne.md
@@ -1,0 +1,7 @@
+---
+layout: collections-list-lag
+title: Stjerne
+permalink: /lag/stjerne/
+---
+
+Stjernelaget sin side kommer her

--- a/lag/ungdom.md
+++ b/lag/ungdom.md
@@ -1,7 +1,7 @@
 ---
-layout: collections-list
+layout: collections-list-lag
 title: Ungdom
 permalink: /lag/ungdom/
 ---
 
-Oversikt over barne-lagene
+Oversikt over ungdoms-lagene

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -418,6 +418,12 @@ a, a:visited, a:hover {
     color: nth($paletteRed, 10);
 }
 
+.button--primary:visited {
+    color: white;
+}
+
+
+
 // Misc
 
 


### PR DESCRIPTION
Hvis man klikker på lag i hovedmenyen får man en oversikts-side over alle lagene, sortert først etter hovedkategori (barn, ungdom, senior, stjerne) – og deretter sortert etter alder innenfor hver enkelt kategori. Det går også an å klikke på kategori-tittelen, for å få en oversikt over bare de lagene i den kategorien. 
Hvis man klikker på "les mer" på forsiden går man rett til oversikten for hovedkategori.
Lag-navn er klikkbare, og går til hvert enkelt lag sin side. 
